### PR TITLE
feat: Replace HashMap with IndexMap for properties in GLTF extensions and Tileset statistics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 name = "cesiumtiles"
 
 [dependencies]
+indexmap = { version = "2.8.0", features = ["rayon", "serde"] }
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = { version = "1.0.125", features = ["float_roundtrip", "indexmap"] }
 serde_repr = "0.1.19"

--- a/src/models/gltf_extensions/gltf/ext_structural_metadata.rs
+++ b/src/models/gltf_extensions/gltf/ext_structural_metadata.rs
@@ -2,6 +2,7 @@
 //!
 //! https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_structural_metadata
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -81,8 +82,8 @@ pub struct Class {
     pub description: Option<String>,
 
     /// A dictionary, where each key is a property ID and each value is an object defining the property.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub properties: HashMap<String, ClassProperty>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub properties: IndexMap<String, ClassProperty>,
 
     /// JSON object with extension-specific objects.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -288,8 +289,8 @@ pub struct PropertyTable {
     pub count: u32,
 
     /// A dictionary, where each key corresponds to a property ID and each value is an object describing where property values are stored.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub properties: HashMap<String, PropertyTableProperty>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub properties: IndexMap<String, PropertyTableProperty>,
 
     /// JSON object with extension-specific objects.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models/tileset.rs
+++ b/src/models/tileset.rs
@@ -357,7 +357,6 @@ pub struct Tileset {
 #[serde(deny_unknown_fields)]
 pub struct Statistics {
     /// A dictionary, where each key corresponds to a class ID in the `classes` dictionary of the metatata schema that was defined for the tileset that contains these statistics. Each value is an object containing statistics about entities that conform to the class.
-
     #[serde(skip_serializing_if = "Option::is_none")]
     pub classes: Option<HashMap<String, StatisticsClass>>,
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated enhanced processing capabilities that improve data ordering and serialization, supporting more efficient handling of model metadata.

- **Refactor**
  - Optimized metadata management by updating how properties are stored and streamlined statistical reporting by removing an obsolete data field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->