### PR TITLE
Added support for google photorealistic tiles

### DIFF
--- a/src/models/tileset.rs
+++ b/src/models/tileset.rs
@@ -189,7 +189,7 @@ pub struct Content {
     pub extra: Option<Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Refine {
     Add,

--- a/src/models/tileset.rs
+++ b/src/models/tileset.rs
@@ -245,6 +245,10 @@ pub struct Tile {
     /// Application-specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra: Option<Value>,
+
+    /// Application-specific data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extras: Option<Value>,
 }
 
 impl Default for Tile {
@@ -264,6 +268,7 @@ impl Default for Tile {
             children: None,
             extensions: None,
             extra: None,
+            extras: None,
         }
     }
 }

--- a/src/models/tileset.rs
+++ b/src/models/tileset.rs
@@ -24,6 +24,10 @@ pub struct Asset {
     /// Application-specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra: Option<Value>,
+
+    /// Application-specific data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extras: Option<Value>,
 }
 
 impl Default for Asset {
@@ -33,6 +37,7 @@ impl Default for Asset {
             tileset_version: None,
             extensions: None,
             extra: None,
+            extras: None,
         }
     }
 }


### PR DESCRIPTION
<!-- Close or Related Issues -->

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- Added `Clone` and `Copy` traits to the `Refine` enum to enable copying of refinement strategy values
- Added support for the `extras` field in the `Tile` struct to store additional application-specific data alongside the existing `extra` field

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし