### PR TITLE
fix: `tileset.json` use IndexMap for properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,7 @@ on:
     tags:
       - "*"
   pull_request:
-    paths:
-      - "nusamai-*/**"
-      - ".github/**"
-      - "*"
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -19,42 +16,16 @@ env:
   ACTION_LOG_DISABLE: true
 
 jobs:
-  check:
-    name: cargo check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Check
-        run: cargo check --all
-
-  style:
-    name: cargo fmt
-    needs: check
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
-      - name: rustfmt
+          components: rustfmt, clippy
+      - name: Format check
         run: cargo fmt --all -- --check
-
-  warnings:
-    runs-on: ubuntu-latest
-    needs: check
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - name: rustfmt
+      - name: Clippy
         run: cargo clippy --all -- -D warnings
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Run tests
+      - name: Test
         run: cargo test --workspace --all-targets --all-features

--- a/src/models/styling.rs
+++ b/src/models/styling.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default, rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
-struct Style {
+pub struct Style {
     /// A dictionary object of `expression` strings mapped to a variable name key that may be referenced throughout the style. If an expression references a defined variable, it is replaced with the evaluated result of the corresponding expression.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub defines: Option<HashMap<String, Expression>>, // default: None
@@ -64,7 +64,7 @@ type ColorExpression = String;
 type NumberExpression = Value; // float | str
 
 /// A series of property names and the `expression` to evaluate for the value of that property."""
-type Meta = HashMap<String, Expression>;
+pub type Meta = HashMap<String, Expression>;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]

--- a/src/models/tileset.rs
+++ b/src/models/tileset.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
 use serde_json::Value;
 
 /// Metadata about the entire tileset.
@@ -316,7 +317,7 @@ pub struct Tileset {
 
     /// (deprecated) A dictionary object of metadata about per-feature properties.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub properties: Option<HashMap<String, Value>>,
+    pub properties: Option<IndexMap<String, Value>>,
 
     /// An object defining the structure of metadata classes and enums. When this is defined, then `schemaUri` shall be undefined.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Overview

This PR replaced properties with IndexMap type as the frontend (PLATEAU-VIEW) requires a fixed object key order in output JSON.

Also fixed some warnings in main branch.

Also modified CI to let it always run. Simplify CI to reduce setup overhead (since this is a tiny repo).