### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cesiumtiles-rs
+  namespace: reearth
+  description: '[WIP] 3D Tiles (JSON models) for Rust'
+  annotations:
+    github.com/project-slug: reearth/cesiumtiles-rs
+  links:
+  - url: https://github.com/reearth/cesiumtiles-rs
+    title: GitHub
+    icon: github
+  tags:
+  - rust
+spec:
+  type: service
+  lifecycle: experimental
+  owner: reearth/flow


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `cesiumtiles-rs` (namespace `reearth`)
- **Owner:** `reearth/flow`
- **Type / lifecycle:** `service` / `experimental`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.